### PR TITLE
Fixing SF4.3+ deprecation notice for `TreeBuilder`

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,8 +17,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('spiechu_symfony_commons');
+        $treeBuilder = new TreeBuilder('spiechu_symfony_commons');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('spiechu_symfony_commons');
+        }
 
         $this->addGetMethodOverride($rootNode);
         $this->addResponseSchemaValidation($rootNode);


### PR DESCRIPTION
Fixing Symfony 4.3+ about `Symfony\Component\Config\Definition\Builder\TreeBuilder` deprecation notice, using method `getRootNode()` instead of `root()` method.